### PR TITLE
v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.0.1 (2019-04-15)
+
+fix: mount middleware in main router after init.
+
+After `bastion.New` and init mux with middlewares, ping and debug handlers if you try to use a middleware the app panic.
+
 ## v3.0.0 (2019-04-15)
 
 ### Features

--- a/bastion_internal_test.go
+++ b/bastion_internal_test.go
@@ -61,7 +61,7 @@ func TestPrintRoutes(t *testing.T) {
 		r.Delete("/", handler) // DELETE /todos/{id} - delete a single todo by :id
 	})
 
-	printRoutes(app.Mux, app.ProfilerRoutePrefix, &app.logger)
+	mountRoutes(app.Mux, app.Options, &app.logger)
 	assert.NotContains(t, out.String(), `"/debug"`)
 	assert.Contains(t, out.String(), `"message":"GET /"`)
 	assert.Contains(t, out.String(), `"message":"POST /"`)
@@ -121,4 +121,16 @@ func TestResolveAddressPanic(t *testing.T) {
 		resolveAddress([]string{":3000", ":8080"}, nil)
 	}
 	assert.PanicsWithValue(t, "too much parameters", f)
+}
+
+func TestDefaultBastion(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	mountRoutes(app.Mux, app.Options, &app.logger)
+	e := Tester(t, app)
+	e.GET("/ping").
+		Expect().
+		Status(http.StatusOK).
+		Text().Equal("pong")
 }


### PR DESCRIPTION
## v3.0.1 (2019-04-15)

fix: mount middleware in main router after init.

After `bastion.New` and init mux with middlewares, ping and debug handlers if you try to use a middleware the app panic.