### PR TITLE
feat: add wrap response writer middleware

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,3 +52,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/felixge/httpsnoop"
+  version = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ InternalError | Intercept responses to verify if his status code is >= 500. If s
 Name | Description
 ---- | -----------
 Listing | Parses the url from a request and stores a [listing.Listing](https://github.com/ifreddyrondon/bastion/blob/master/middleware/listing/listing.go#L11) on the context, it can be accessed through middleware.GetListing.
+WrapResponseWriter | provides an easy way to capture http related metrics from your application's http.Handlers or event hijack the response. 
 
 Checkout for references, examples, options and docu in [middleware](https://github.com/ifreddyrondon/bastion/blob/master/middleware) or [chi](https://github.com/go-chi/chi/tree/master#middlewares) for more middlewares. 
 

--- a/middleware/_example/main.go
+++ b/middleware/_example/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"github.com/ifreddyrondon/bastion"
+	"github.com/ifreddyrondon/bastion/middleware"
+)
+
+func h(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(201)
+	w.Write([]byte("created"))
+}
+
+func defaultMiddle(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		m, snoop := middleware.WrapResponseWriter(w)
+		next.ServeHTTP(snoop, r)
+		fmt.Println(m.Code)
+		fmt.Println(m.Bytes)
+	}
+	return http.HandlerFunc(fn)
+}
+
+func copyWriterMiddle(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		var out bytes.Buffer
+		m, snoop := middleware.WrapResponseWriter(w, middleware.WriteHook(middleware.CopyWriterHook(&out)))
+		next.ServeHTTP(snoop, r)
+		fmt.Println(m.Code)
+		fmt.Println(m.Bytes)
+		fmt.Println(out.String())
+	}
+	return http.HandlerFunc(fn)
+}
+
+func hijackWriterMiddle(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		var out bytes.Buffer
+		m, snoop := middleware.WrapResponseWriter(w, middleware.WriteHook(middleware.HijackWriteHook(&out)))
+		next.ServeHTTP(snoop, r)
+		fmt.Println(m.Code)
+		fmt.Println(m.Bytes)
+		fmt.Println(out.String())
+	}
+	return http.HandlerFunc(fn)
+}
+
+func main() {
+	app := bastion.New()
+	app.With(defaultMiddle).Get("/", h)
+	app.With(copyWriterMiddle).Get("/copy", h)
+	app.With(hijackWriterMiddle).Get("/hijack", h)
+	app.Serve()
+}

--- a/middleware/internal_error.go
+++ b/middleware/internal_error.go
@@ -6,57 +6,11 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/felixge/httpsnoop"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 
 	"github.com/ifreddyrondon/bastion/render"
 )
-
-// hooks defines WriteHeader and Write methods interceptors for methods included in
-// http.ResponseWriter.
-func hooks(wc *writerCollector) httpsnoop.Hooks {
-	return httpsnoop.Hooks{
-		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
-			return func(code int) {
-				if !wc.wroteHeader {
-					wc.code = code
-					wc.wroteHeader = true
-				}
-			}
-		},
-		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
-			return func(p []byte) (int, error) {
-				n, err := wc.buf.Write(p)
-				wc.bytes += int64(n)
-				wc.wroteHeader = true
-				return n, err
-			}
-		},
-	}
-}
-
-type writerCollector struct {
-	// Code is the first http response code passed to the WriteHeader func of
-	// the ResponseWriter. If no such call is made, a default code of 200 is
-	// assumed instead.
-	code int
-	// Duration is the time it took to execute the handler.
-	// Duration time.Duration
-	wroteHeader bool
-	// bytes is the number of bytes successfully written by the Write or
-	// ReadFrom function of the ResponseWriter. ResponseWriters may also write
-	// data to their underlying connection directly (e.g. headers), but those
-	// are not tracked. Therefor the number of Written bytes will usually match
-	// the size of the response body.
-	bytes int64
-	// buf store all the []bytes internally when ResponseWriter.Write is called.
-	buf bytes.Buffer
-}
-
-func newWriterCollector() *writerCollector {
-	return &writerCollector{code: http.StatusOK}
-}
 
 var internalErrDefaultMsg = errors.New("looks like something went wrong")
 
@@ -102,23 +56,23 @@ func internalErrCfg(opts ...func(*internalErr)) *internalErr {
 // The real error keeps logged.
 func InternalError(opts ...func(*internalErr)) func(http.Handler) http.Handler {
 	cfg := internalErrCfg(opts...)
-
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			m := newWriterCollector()
-
-			snoop := httpsnoop.Wrap(w, hooks(m))
+			buf := &bytes.Buffer{}
+			writeHeaderHook := WriteHeaderHook(HijackWriteHeaderHook)
+			writeHook := WriteHook(HijackWriteHook(buf))
+			m, snoop := WrapResponseWriter(w, writeHeaderHook, writeHook)
 			defer func() {
-				if m.code >= 500 {
+				if m.Code >= 500 {
 					cfg.logger.Info().
 						Str("component", "internal error middleware").
-						Int("status", m.code).
-						Msg(m.buf.String())
+						Int("status", m.Code).
+						Msg(buf.String())
 					cfg.render.InternalServerError(w, cfg.defaultErr)
 					return
 				}
-				w.WriteHeader(m.code)
-				w.Write(m.buf.Bytes())
+				w.WriteHeader(m.Code)
+				w.Write(buf.Bytes())
 			}()
 			next.ServeHTTP(snoop, r)
 		}

--- a/middleware/wrap_response_writer.go
+++ b/middleware/wrap_response_writer.go
@@ -1,0 +1,153 @@
+package middleware
+
+import (
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/felixge/httpsnoop"
+)
+
+var (
+	// CollectHeaderHook capture the response code into a WriterMetricsCollector and forward the execution to the main
+	// WriteHeader method. It's the default hook for WriteHeader when WrapWriter is used.
+	CollectHeaderHook = func(collector *WriterMetricsCollector) func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+		return func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(code int) {
+				next(code)
+				collector.locker.Lock()
+				defer collector.locker.Unlock()
+				if !collector.wroteHeader {
+					collector.Code = code
+					collector.wroteHeader = true
+				}
+			}
+		}
+	}
+
+	// HijackWriteHeaderHook capture the response code into a WriterMetricsCollector. Warning it'll not forward to the
+	// main WriteHeader method execution.
+	HijackWriteHeaderHook = func(collector *WriterMetricsCollector) func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+		return func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(code int) {
+				collector.locker.Lock()
+				defer collector.locker.Unlock()
+				if !collector.wroteHeader {
+					collector.Code = code
+					collector.wroteHeader = true
+				}
+			}
+		}
+	}
+
+	// CollectBytesHook capture the amount of bytes into a WriterMetricsCollector and forward the execution to the main
+	// Write method. It's the default hook for Write when WrapWriter is used.
+	CollectBytesHook = func(collector *WriterMetricsCollector) func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+		return func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(p []byte) (int, error) {
+				n, err := next(p)
+				collector.locker.Lock()
+				defer collector.locker.Unlock()
+				collector.Bytes += int64(n)
+				collector.wroteHeader = true
+				return n, err
+			}
+		}
+	}
+)
+
+// CopyWriterHook makes a copy of the bytes into a io.Writer and forward the execution to the main Write method.
+// It'll save the amount of bytes into a WriterMetricsCollector.
+func CopyWriterHook(w io.Writer) func(collector *WriterMetricsCollector) func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+	return func(collector *WriterMetricsCollector) func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+		return func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(p []byte) (int, error) {
+				n, err := next(p)
+				collector.locker.Lock()
+				defer collector.locker.Unlock()
+				w.Write(p)
+				collector.Bytes += int64(n)
+				collector.wroteHeader = true
+				return n, err
+			}
+		}
+	}
+}
+
+// HijackWriteHook write the response bytes into a io.Writer. It'll save the amount of bytes into
+// a WriterMetricsCollector. Warning it'll not forward to the main Write method execution.
+func HijackWriteHook(w io.Writer) func(collector *WriterMetricsCollector) func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+	return func(collector *WriterMetricsCollector) func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+		return func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(p []byte) (int, error) {
+				collector.locker.Lock()
+				defer collector.locker.Unlock()
+				n, err := w.Write(p)
+				collector.Bytes += int64(n)
+				collector.wroteHeader = true
+				return n, err
+			}
+		}
+	}
+}
+
+// WriterMetricsCollector holds metrics captured from writer.
+type WriterMetricsCollector struct {
+	// Code is the first http response code passed to the WriteHeader func of
+	// the ResponseWriter. If no such call is made, a default code of 200 is
+	// assumed instead.
+	Code int
+	// bytes is the number of bytes successfully written by the Write or
+	// ReadFrom function of the ResponseWriter. ResponseWriters may also write
+	// data to their underlying connection directly (e.g. headers), but those
+	// are not tracked. Therefor the number of Written bytes will usually match
+	// the size of the response body.
+	Bytes       int64
+	wroteHeader bool
+	locker      sync.Mutex
+}
+
+// WriteHeaderHook define the method interceptor when WriteHeader is called.
+func WriteHeaderHook(hook func(*WriterMetricsCollector) func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc) func(*wrapWriterOpts) {
+	return func(opts *wrapWriterOpts) {
+		opts.writeHeaderHook = hook
+	}
+}
+
+// WriteHook define the method interceptor when Write is called.
+func WriteHook(hook func(*WriterMetricsCollector) func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc) func(*wrapWriterOpts) {
+	return func(opts *wrapWriterOpts) {
+		opts.writeHook = hook
+	}
+}
+
+type wrapWriterOpts struct {
+	writeHeaderHook func(*WriterMetricsCollector) func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc
+	writeHook       func(*WriterMetricsCollector) func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc
+}
+
+func wrapWriterSetupCfg(opts ...func(*wrapWriterOpts)) *wrapWriterOpts {
+	cfg := &wrapWriterOpts{
+		writeHeaderHook: CollectHeaderHook,
+		writeHook:       CollectBytesHook,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+// WrapResponseWriter defines a set of method interceptors for methods included in
+// http.ResponseWriter as well as some others. You can think of them as
+// middleware for the function calls they target.
+// It response with a wrapped ResponseWriter and WriterMetricsCollector with some useful metrics.
+func WrapResponseWriter(w http.ResponseWriter, opts ...func(*wrapWriterOpts)) (*WriterMetricsCollector, http.ResponseWriter) {
+	cfg := wrapWriterSetupCfg(opts...)
+	collector := &WriterMetricsCollector{Code: http.StatusOK}
+	hooks := httpsnoop.Hooks{
+		WriteHeader: cfg.writeHeaderHook(collector),
+		Write:       cfg.writeHook(collector),
+	}
+	snoop := httpsnoop.Wrap(w, hooks)
+	return collector, snoop
+}

--- a/middleware/wrap_response_writer_test.go
+++ b/middleware/wrap_response_writer_test.go
@@ -1,0 +1,146 @@
+package middleware_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/gavv/httpexpect.v1"
+
+	"github.com/ifreddyrondon/bastion/middleware"
+)
+
+func TestWrapResponseWriterDefaultHooks(t *testing.T) {
+	t.Parallel()
+
+	var metrics middleware.WriterMetricsCollector
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(201)
+		w.Write([]byte("created"))
+	})
+
+	m := func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			m, snoop := middleware.WrapResponseWriter(w)
+			defer func() {
+				metrics = *m
+			}()
+			next.ServeHTTP(snoop, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+
+	server := httptest.NewServer(m(h))
+	defer server.Close()
+
+	e := httpexpect.New(t, server.URL)
+	e.GET("/").Expect().Status(201).Body().Equal("created")
+
+	assert.Equal(t, 201, metrics.Code)
+	assert.Equal(t, int64(7), metrics.Bytes)
+}
+
+func TestWrapResponseWriterDefaultWithOverwriteWriteHeaderHook(t *testing.T) {
+	t.Parallel()
+
+	var metrics middleware.WriterMetricsCollector
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(201)
+		w.Write([]byte("created"))
+	})
+
+	m := func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			m, snoop := middleware.WrapResponseWriter(
+				w,
+				middleware.WriteHeaderHook(middleware.HijackWriteHeaderHook),
+			)
+			defer func() {
+				metrics = *m
+			}()
+			next.ServeHTTP(snoop, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+
+	server := httptest.NewServer(m(h))
+	defer server.Close()
+
+	e := httpexpect.New(t, server.URL)
+	e.GET("/").Expect().Status(200).Body().Equal("created")
+
+	assert.Equal(t, 201, metrics.Code)
+	assert.Equal(t, int64(7), metrics.Bytes)
+}
+
+func TestWrapResponseWriterDefaultWithCopyWriterHook(t *testing.T) {
+	t.Parallel()
+
+	var metrics middleware.WriterMetricsCollector
+	var out bytes.Buffer
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(201)
+		w.Write([]byte("created"))
+	})
+
+	m := func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			m, snoop := middleware.WrapResponseWriter(
+				w,
+				middleware.WriteHook(middleware.CopyWriterHook(&out)),
+			)
+			defer func() {
+				metrics = *m
+			}()
+			next.ServeHTTP(snoop, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+
+	server := httptest.NewServer(m(h))
+	defer server.Close()
+
+	e := httpexpect.New(t, server.URL)
+	e.GET("/").Expect().Status(201).Body().Equal("created")
+
+	assert.Equal(t, 201, metrics.Code)
+	assert.Equal(t, int64(7), metrics.Bytes)
+	assert.Equal(t, out.String(), "created")
+}
+
+func TestWrapResponseWriterDefaultWithOverwriteWriteHook(t *testing.T) {
+	t.Parallel()
+
+	var metrics middleware.WriterMetricsCollector
+	var out bytes.Buffer
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(201)
+		w.Write([]byte("created"))
+	})
+
+	m := func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			m, snoop := middleware.WrapResponseWriter(
+				w,
+				middleware.WriteHook(middleware.HijackWriteHook(&out)),
+			)
+			defer func() {
+				metrics = *m
+			}()
+			next.ServeHTTP(snoop, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+
+	server := httptest.NewServer(m(h))
+	defer server.Close()
+
+	e := httpexpect.New(t, server.URL)
+	e.GET("/").Expect().Status(201).Body().Equal("")
+
+	assert.Equal(t, 201, metrics.Code)
+	assert.Equal(t, int64(7), metrics.Bytes)
+	assert.Equal(t, out.String(), "created")
+}


### PR DESCRIPTION
WrapResponseWriter, provides an easy way to capture http related metrics from your application's http.Handlers or event hijack the response